### PR TITLE
Fixed masking of startup exception with shutdown exception in IAGD

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -45,6 +45,18 @@ public class Exceptions
         return exception;
     }
 
+    public static <T extends Throwable> T withSuppressed( T exception, Throwable... suppressed )
+    {
+        if ( suppressed != null )
+        {
+            for ( Throwable s : suppressed )
+            {
+                exception.addSuppressed( s );
+            }
+        }
+        return exception;
+    }
+
     public static RuntimeException launderedException( Throwable exception )
     {
         return launderedException( UNEXPECTED_MESSAGE, exception );

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
@@ -20,8 +20,11 @@
 package org.neo4j.helpers;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TestExceptions
@@ -96,6 +99,23 @@ public class TestExceptions
 
         // THEN
         assertEquals( prependedMessage, exception.getMessage() );
+    }
+
+    @Test
+    public void shouldAddSuppressedExceptions()
+    {
+        // Given
+        RuntimeException exception = new RuntimeException();
+
+        RuntimeException suppressed1 = new RuntimeException();
+        RuntimeException suppressed2 = new RuntimeException();
+
+        // When
+        RuntimeException result = Exceptions.withSuppressed( exception, suppressed1, suppressed2 );
+
+        // Then
+        assertSame( exception, result );
+        assertArrayEquals( new Throwable[]{suppressed1, suppressed2}, result.getSuppressed() );
     }
 
     private static class LevelOneException extends Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.kernel.impl.factory.DataSourceModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+
+public class GraphDatabaseFacadeFactoryTest
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldThrowAppropriateExceptionIfStartFails()
+    {
+        // Given
+        RuntimeException startupError = new RuntimeException();
+
+        GraphDatabaseFacadeFactory db = newFaultyGraphDatabaseFacadeFactory( startupError );
+        GraphDatabaseFacade mockFacade = mock( GraphDatabaseFacade.class );
+        try
+        {
+            // When
+            db.newFacade( Collections.<String, String>emptyMap(), mock( GraphDatabaseFacadeFactory.Dependencies.class ),
+                    mockFacade );
+            fail( "Should have thrown " + RuntimeException.class );
+        }
+        catch ( RuntimeException exception )
+        {
+            // Then
+            assertEquals( startupError, Exceptions.rootCause( exception ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowAppropriateExceptionIfBothStartAndShutdownFail()
+    {
+        // Given
+        RuntimeException startupError = new RuntimeException();
+        RuntimeException shutdownError = new RuntimeException();
+
+        GraphDatabaseFacadeFactory db = newFaultyGraphDatabaseFacadeFactory( startupError );
+        GraphDatabaseFacade mockFacade = mock( GraphDatabaseFacade.class );
+        doThrow( shutdownError ).when( mockFacade ).shutdown();
+        try
+        {
+            // When
+            db.newFacade( Collections.<String, String>emptyMap(), mock( GraphDatabaseFacadeFactory.Dependencies.class ),
+                    mockFacade );
+            fail( "Should have thrown " + RuntimeException.class );
+        }
+        catch ( RuntimeException exception )
+        {
+            // Then
+            assertEquals( shutdownError, exception );
+            assertEquals( startupError, Exceptions.rootCause( exception.getSuppressed()[0] ) );
+        }
+    }
+
+    private GraphDatabaseFacadeFactory newFaultyGraphDatabaseFacadeFactory( final RuntimeException startupError )
+    {
+        return new GraphDatabaseFacadeFactory()
+        {
+            @Override
+            protected PlatformModule createPlatform( Map<String, String> params, Dependencies dependencies,
+                                                     GraphDatabaseFacade graphDatabaseFacade )
+            {
+                PlatformModule module = new PlatformModule( mock( Map.class ), mock( Dependencies.class, RETURNS_MOCKS ),
+                        mock( GraphDatabaseFacade.class ) );
+                module.life = mock( LifeSupport.class );
+                module.storeDir = mock( File.class );
+                doThrow( startupError ).when( module.life ).start();
+                return module;
+            }
+
+            @Override
+            protected EditionModule createEdition( PlatformModule platformModule )
+            {
+                return null;
+            }
+
+            @Override
+            protected DataSourceModule createDataSource( Dependencies dependencies, PlatformModule platformModule,
+                                                         EditionModule editionModule )
+            {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This is a forward port of #4458 from 2.2, adjusted to the new
 realities of the refactoring around IAGD to Facade and friends.
